### PR TITLE
stw correction

### DIFF
--- a/odincal/odincal/level0_file_importer.py
+++ b/odincal/odincal/level0_file_importer.py
@@ -6,6 +6,9 @@ from sqlalchemy import func, Column, String, Date, DateTime
 from odincal.database import OdincalDB
 
 
+STW_ODIN_REBOOT = 3 * 2 ** 32
+
+
 class Level0File(OdincalDB.Base):
     """A class to register level0-files"""
     __tablename__ = 'level0_files'
@@ -24,15 +27,18 @@ class Level0File(OdincalDB.Base):
     def timestamp_from_filename(self):
         """ return datetime from filename """
         stw = int(self.name + '0', base=16)
-        # reference stw and mjd
-        stw0 = 6161431982
-        mjd0 = 56416.7782534
-        rate = 1 / 16.0016444
-        # calculate mjd for the filename stw
-        mjd = mjd0 + (stw - stw0) * rate / 86400.0
-        # get a time stamp
-        timestamp = datetime.date(datetime(1858, 11, 17) + timedelta(days=mjd))
-        return timestamp
+        if stw >= STW_ODIN_REBOOT:
+            a = 4.99205631 * 1e4
+            b = 7.23413455 * 1e-7
+            c = -4.25743315 * 1e-21
+            d = 0.
+        else:
+            a = 5.19601792 * 1e4
+            b = 7.23308989 * 1e-7
+            c = -6.81289563 * 1e-22
+            d = 2.47714080 * 1e-32
+        mjd = (a + b * stw + c * stw ** 2 + d * stw ** 3)
+        return datetime.date(datetime(1858, 11, 17) + timedelta(days=mjd))
 
     def check_file_type(self):
         """ import one file """

--- a/odincal/tests/test_level0.py
+++ b/odincal/tests/test_level0.py
@@ -5,5 +5,7 @@ def test_correction():
     for file_set in [
             ('017f6e6c.ac2', 0 * 2**32),
             ('11f1eafe.fba', 1 * 2**32),
-            ('20683ad2.ac2', 2 * 2**32)]:
+            ('20683ad2.ac2', 2 * 2**32),
+            ('30683ad2.ac2', 3 * 2**32),
+        ]:
         assert stw_correction(file_set[0]) == file_set[1]

--- a/odincal/tests/test_level0_importer.py
+++ b/odincal/tests/test_level0_importer.py
@@ -1,12 +1,28 @@
-"""Import file to database"""
+from datetime import date 
+import pytest
+
 from odincal.level0_file_importer import Level0File
 
 
-def test_timestamp():
+@pytest.mark.parametrize("filename,expect", (
+    ("/path/to/file/00da5210.att", date(2001, 8, 4)),
+    ("/path/to/file/06eaba07.att", date(2004, 10, 25)),
+    ("/path/to/file/07505920.att", date(2005, 1, 10)),
+    ("/path/to/file/0b105c8a.att", date(2007, 1, 8)),
+    ("/path/to/file/1001220d.att", date(2009, 8, 24)),
+    ("/path/to/file/10235ce2.att", date(2009, 9, 19)),
+    ("/path/to/file/15026f16.att", date(2012, 4, 22)),
+    ("/path/to/file/1a5e4dff.att", date(2015, 2, 26)),
+    ("/path/to/file/1a5eeb29.att", date(2015, 2, 27)),
+    ("/path/to/file/20002dd0.att", date(2018, 2, 24)),
+    ("/path/to/file/25726391.att", date(2021, 1, 16)),
+    ("/path/to/file/30085ce9.att", date(2021, 2, 2)),
+    ("/path/to/file/3074223e.att", date(2021, 4, 25)),
+))
+def test_timestamp(filename, expect):
     """Check STW to date approximation"""
-    filename = '/long/path/to/file/1a5ed04b.fba'
     test_file = Level0File(filename)
-    assert test_file.measurement_date.isoformat() == '2015-02-27'
+    assert test_file.measurement_date == expect
 
 
 def test_file_imported():


### PR DESCRIPTION
Jag har fått infromationen att: "New files after the reboot are marked with a leading 3 and all STW_PLN.DAT-files used during the mission is to be found at PDC under directory DAT\STW."  Och har också verifierat att så är fallet.

jag kan bygga dockerimagen och köra testerna med tox inne i dockerimagen.  Det visade sig att vår grundläggande inläsning av data hanterar prefix ändringen. Däremot var jag tvungen att uppdatera en funktion som plockar ut mätdatum för en fil ifrån filnamnet. Utan förändringen i denna PR blir mätdatumet för de nya filerna flera år framåt i tiden, och processas då inte av systemet, eftersom den gällande konfigurationen säger att vi inte ska göra så. 