### PR TITLE
fixing cleancal filter function

### DIFF
--- a/odincal/odincal/frequency_calibration.py
+++ b/odincal/odincal/frequency_calibration.py
@@ -85,7 +85,7 @@ class Spectra(object):
                 else:
                     if_freq = if_freq * 3.6 / 3.9
 
-        if self.current < 0.2 and self.frontend != '572':
+        if self.current < 0.19 and self.frontend != '572':
             self.lofreq = 0.0
 
         self.fcalibrate(self.lofreq, if_freq)

--- a/odincal/odincal/frequency_calibration.py
+++ b/odincal/odincal/frequency_calibration.py
@@ -85,7 +85,7 @@ class Spectra(object):
                 else:
                     if_freq = if_freq * 3.6 / 3.9
 
-        if self.current < 0.25 and self.frontend != '572':
+        if self.current < 0.2 and self.frontend != '572':
             self.lofreq = 0.0
 
         self.fcalibrate(self.lofreq, if_freq)


### PR DESCRIPTION
simplified cleancal filter function that is supposed filter out trec spectrum with clearly too high or low mean values.

A problem was that "dead bands (having only zero values)" were not filtered out properly for calculating
averages, resulting in that all mean trec spectra often had values below the low threshold value, and thus no trec
spectrum remained for further processing. 
 